### PR TITLE
Use ArduinoMDNS from PIO Registry

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -16,7 +16,10 @@ description = WiFi Web Server LED control via web of things (e.g., iot.mozilla.o
 
 [common]
 ; https://platformio.org/lib/show/299/WiFi101
-lib_deps = WiFi101
+; https://platformio.org/lib/show/2848/ArduinoMDNS
+lib_deps =
+  WiFi101
+  ArduinoMDNS
 
 [env:samw25]
 platform = atmelsam


### PR DESCRIPTION
Please remove https://github.com/mozilla-iot/http-on-off-wifi101/tree/master/lib/ArduinoMDNS lirbary